### PR TITLE
add bearblog rss integration

### DIFF
--- a/_api/retrieveFromRss.js
+++ b/_api/retrieveFromRss.js
@@ -38,7 +38,6 @@ export default async (req) => {
                 headers: {
                     'Netlify-Vary': 'query=page',
                     'Netlify-CDN-Cache-Control': 'public, max-age=300, stale-while-revalidate=30, durable',
-                    'Content-Type': 'application/json'
                 }
             })
         } else {

--- a/_api/retrieveFromRss.js
+++ b/_api/retrieveFromRss.js
@@ -12,7 +12,7 @@ export default async (req) => {
         const MAX_PAGE_SIZE = 6
 
         const result = await fetch('https://tilda.bearblog.dev/feed/', {
-            'headers': {
+            headers: {
                 'User-Agent': 'flourite (github.com/tilda/web, mailto:me@til.pm)',
                 'Accept': 'application/atom+xml'
             }
@@ -30,25 +30,26 @@ export default async (req) => {
                 throw new Error(`Requested page ${pageParam} does not currently exist`)
             }
 
-            return new Response(JSON.stringify({
+            return Response.json({
                 'current_page': pageParam,
                 'max_pages': PAGE_LIMIT,
                 'items': feed.entries.slice((pageParam - 1) * MAX_PAGE_SIZE, pageParam * MAX_PAGE_SIZE)
-            }), {
-                'headers': {
+            }, {
+                headers: {
                     'Netlify-Vary': 'query=page',
-                    'Netlify-CDN-Cache-Control': 'public, max-age=300, stale-while-revalidate=30, durable'
+                    'Netlify-CDN-Cache-Control': 'public, max-age=300, stale-while-revalidate=30, durable',
+                    'Content-Type': 'application/json'
                 }
             })
         } else {
-            return new Response(null, { status: 204 })
+            return Response(null, { status: 204 })
         }
     } catch (err) {
         console.log(err)
 
-        return new Response(JSON.stringify({
+        return Response.json({
             'error': err.toString()
-        }), {
+        }, {
             status: 400
         })
     }

--- a/_api/retrieveFromRss.js
+++ b/_api/retrieveFromRss.js
@@ -1,0 +1,48 @@
+import { parseAtomFeed } from 'feedsmith'
+
+export const config = {
+    path: "/retrieveFromRss/:page?"
+}
+
+export default async (_req, ctx) => {
+    try {
+        let { pageParam } = ctx.params
+        if (pageParam === null) {
+            pageParam = 1
+        } else {
+            pageParam = Number.parseInt(pageParam, 10).toFixed(0)
+        }
+        const MAX_PAGE_SIZE = 6
+
+        const result = fetch('https://tilda.bearblog.dev/feed', {
+            headers: {
+                'User-Agent': 'flourite (github.com/tilda/web, mailto:me@til.pm)',
+                'Accept': 'application/atom+xml'
+            }
+        }).catch((err) => {
+            throw new Error(`Caught error while requesting Bear RSS feed: ${err}`)
+        }).then((res) => {
+            return parseAtomFeed(res.text)
+        })
+
+        const PAGE_LIMIT = (result.feed.items.length / MAX_PAGE_SIZE + 1).toFixed(0)
+
+        if (pageParam > PAGE_LIMIT) {
+            throw new Error(`Requested page ${pageParam} does not currently exist`)
+        }
+
+        return new Response(JSON.stringify({
+            'status': 'ok',
+            'current_page': pageParam,
+            'max_pages': PAGE_LIMIT,
+            'items': result.feed.items.slice((pageParam - 1) * MAX_PAGE_SIZE, pageParam * MAX_PAGE_SIZE)
+        }))
+    } catch (err) {
+        return new Response(JSON.stringify({
+            'status': 'err',
+            'error': err
+        }), {
+            status: 400
+        })
+    }
+}

--- a/_api/retrieveFromRss.js
+++ b/_api/retrieveFromRss.js
@@ -1,46 +1,55 @@
 import { parseAtomFeed } from 'feedsmith'
 
-export const config = {
-    path: "/retrieveFromRss/:page?"
-}
-
-export default async (_req, ctx) => {
+export default async (req) => {
     try {
-        let { pageParam } = ctx.params
-        if (pageParam === null) {
-            pageParam = 1
+        const REQUEST_URL = new URL(req.url)
+        if (REQUEST_URL.searchParams.get("page")) {
+            pageParam = REQUEST_URL.searchParams.get("page")
         } else {
-            pageParam = Number.parseInt(pageParam, 10).toFixed(0)
+            pageParam = 1
         }
+
         const MAX_PAGE_SIZE = 6
 
-        const result = fetch('https://tilda.bearblog.dev/feed', {
-            headers: {
+        const result = await fetch('https://tilda.bearblog.dev/feed/', {
+            'headers': {
                 'User-Agent': 'flourite (github.com/tilda/web, mailto:me@til.pm)',
                 'Accept': 'application/atom+xml'
             }
-        }).catch((err) => {
-            throw new Error(`Caught error while requesting Bear RSS feed: ${err}`)
-        }).then((res) => {
-            return parseAtomFeed(res.text)
         })
-
-        const PAGE_LIMIT = (result.feed.items.length / MAX_PAGE_SIZE + 1).toFixed(0)
-
-        if (pageParam > PAGE_LIMIT) {
-            throw new Error(`Requested page ${pageParam} does not currently exist`)
+        if (!result.ok) {
+            throw new Error(`Caught HTTP error code ${result.status} while requesting from Bear`)
         }
+        const BEAR_RESPONSE = await result.text()
+        const feed = parseAtomFeed(BEAR_RESPONSE)
 
-        return new Response(JSON.stringify({
-            'status': 'ok',
-            'current_page': pageParam,
-            'max_pages': PAGE_LIMIT,
-            'items': result.feed.items.slice((pageParam - 1) * MAX_PAGE_SIZE, pageParam * MAX_PAGE_SIZE)
-        }))
+        if (feed.entries) {
+            const PAGE_LIMIT = Number.parseInt((feed.entries.length / MAX_PAGE_SIZE + 1).toFixed(0), 10)
+
+            if (pageParam > PAGE_LIMIT) {
+                throw new Error(`Requested page ${pageParam} does not currently exist`)
+            }
+
+            return new Response(JSON.stringify({
+                'status': 'ok',
+                'current_page': pageParam,
+                'max_pages': PAGE_LIMIT,
+                'items': feed.entries.slice((pageParam - 1) * MAX_PAGE_SIZE, pageParam * MAX_PAGE_SIZE)
+            }), {
+                'headers': {
+                    'Netlify-Vary': 'query=page',
+                    'Netlify-CDN-Cache-Control': 'public, max-age=300, stale-while-revalidate=30, durable'
+                }
+            })
+        } else {
+            return new Response(null, { status: 204 })
+        }
     } catch (err) {
+        console.log(err)
+
         return new Response(JSON.stringify({
             'status': 'err',
-            'error': err
+            'error': err.toString()
         }), {
             status: 400
         })

--- a/_api/retrieveFromRss.js
+++ b/_api/retrieveFromRss.js
@@ -31,7 +31,6 @@ export default async (req) => {
             }
 
             return new Response(JSON.stringify({
-                'status': 'ok',
                 'current_page': pageParam,
                 'max_pages': PAGE_LIMIT,
                 'items': feed.entries.slice((pageParam - 1) * MAX_PAGE_SIZE, pageParam * MAX_PAGE_SIZE)
@@ -48,7 +47,6 @@ export default async (req) => {
         console.log(err)
 
         return new Response(JSON.stringify({
-            'status': 'err',
             'error': err.toString()
         }), {
             status: 400

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,6 +303,29 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1055,6 +1078,7 @@
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -1882,7 +1906,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3138,7 +3161,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3581,6 +3603,7 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -4704,7 +4727,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5082,7 +5104,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -5271,7 +5292,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -6752,7 +6772,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -8139,7 +8160,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -9654,7 +9676,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9760,6 +9781,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10869,6 +10891,7 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -10887,7 +10910,8 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
@@ -11114,7 +11138,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11413,6 +11436,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11471,7 +11495,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11548,7 +11571,6 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",

--- a/src/components/BlogCard.vue
+++ b/src/components/BlogCard.vue
@@ -1,0 +1,15 @@
+<template>
+    <a :href="link">
+        <div class="w-96 h-36 bg-">
+            <div class="text-sm">{{ date }}</div>
+            <h3 class="text-md">{{ title }}</h3>
+            <div class="text-sm">{{ description }}</div>
+        </div>
+    </a>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps(['title', 'description', 'link', 'date'])
+</script>

--- a/src/views/BlogView.vue
+++ b/src/views/BlogView.vue
@@ -1,5 +1,7 @@
 <template>
+    <p>blog hosting kindly provided by <a href="https://tilda.bearblog.dev">bear</a>; <a href="https://tilda.bearblog.dev/feed">RSS feed available here</a>.</p>
 
+    <p class="italic">displaying n posts on page x/x</p>
 </template>
 
 <script setup>


### PR DESCRIPTION
Initial thought: uses netlify function and bearblog rss feed to display post list on site.

Eventually looking to merge with:
- [ ] Finished card component
- [ ] Post list page with pagination done
    - [ ] Check implementation on `retrieveFromRss` route
- [ ] Blog post frontend route + view?
    - [ ] May need another API function if implemented